### PR TITLE
Editor: enable RTL row alignment

### DIFF
--- a/app/src/main/java/com/pilcrowmd/ui/components/Editor.kt
+++ b/app/src/main/java/com/pilcrowmd/ui/components/Editor.kt
@@ -179,7 +179,7 @@ fun MarkdownEditor(
 
                     // Configure editor appearance and behavior
                     editor.setTextSize(editorFontSizeSp)
-                    editor.setWordwrap(true) // Soft wrap, no horizontal scroll
+                    editor.setWordwrap(true, true, true) // Soft wrap with right-aligned RTL rows
                     editor.isLineNumberEnabled = lineNumbersEnabled
 
                     // Sora's default divider margins are too tight — the content text sits flush


### PR DESCRIPTION
## Summary

Enable Sora Editor's built-in right-aligned RTL row support in the existing word-wrapped source editor.

## Why

Pilcrow already uses Sora 0.24.5, which supports bidi rendering, direction-aware cursor movement, and right-aligned RTL rows. The one-argument `setWordwrap(true)` overload keeps RTL row alignment disabled, so Arabic and other RTL languages lines render from the left despite having the correct bidi ordering. Opting into the existing three-argument API avoids custom direction logic or a dependency change.

## Behavior Change

- RTL-based lines are anchored to the right, including wrapped continuations.
- LTR lines remain anchored to the left.
- Mixed lines continue to use Sora's first-strong direction detection.
- The line-number gutter, document bytes, saving, highlighting, undo, and reader mode are unchanged.

## Verification

- `clean testDebugUnitTest testMainDispatcherDebug --rerun-tasks` — 533 tests passed
- `verifyRoborazziDebug` — passed
- `assembleDebug` — passed
